### PR TITLE
Updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,21 @@
 [package]
 name = "geocoding"
 description = "Geocoding library for Rust"
-version = "0.0.3"
+version = "0.0.4"
 authors = ["Stephan Hügel <urschrei@gmail.com>", "Blake Grotewold <hello@grotewold.me>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/georust/geocoding"
 keywords = ["gecoding", "geo", "gis", "geospatial"]
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
-geo-types = "0.2.0"
+failure = "0.1.3"
+geo-types = "0.3.0"
 num-traits = "0.2"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-reqwest ="0.8.5"
-hyper = "0.11.25"
+reqwest ="0.9.5"
+hyper = "0.12.18"
+chrono = { version = "0.4", features = ["serde"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,34 +6,29 @@
 //! As this is the lowest common denominator reverse-geocoding result.
 //! Individual providers may implement additional methods, which return more
 //! finely-structured and/or extensive data, and enable more specific query tuning.
+//! Coordinate data are specified using the [`Point`](struct.Point.html) struct, which has several
+//! convenient `From` implementations to allow for easy construction using primitive types.
+//!
 //! ### A note on Coordinate Order
 //! While individual providers may specify coordinates in either `[Longitude, Latitude]` **or**
 //! `[Latitude, Longitude`] order,
-//! `Geocoding` **always** requires `Point` data in `[Longitude, Latitude]` (`x, y`) order,
+//! `Geocoding` **always** requires [`Point`](struct.Point.html) data in `[Longitude, Latitude]` (`x, y`) order,
 //! and returns data in that order.
 //!
 static UA_STRING: &'static str = "Rust-Geocoding";
-extern crate geo_types;
+
+use chrono;
+use failure::Error;
 pub use geo_types::Point;
-
-extern crate num_traits;
 use num_traits::Float;
-
-#[macro_use]
-extern crate serde_derive;
-
-extern crate serde;
-use serde::Deserialize;
-
-extern crate reqwest;
-use reqwest::{header, Client};
-
-#[macro_use]
-extern crate hyper;
+use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
+use reqwest::Client;
+use serde::{Deserialize, Deserializer};
+use serde_derive::Deserialize;
 
 // The OpenCage geocoding provider
 pub mod opencage;
-pub use opencage::Opencage;
+pub use crate::opencage::Opencage;
 
 /// Reverse-geocode a coordinate.
 ///
@@ -61,7 +56,7 @@ where
     // NOTE TO IMPLEMENTERS: Point coordinates are lon, lat (x, y)
     // You may have to provide these coordinates in reverse order,
     // depending on the provider's requirements (see e.g. OpenCage)
-    fn reverse(&self, point: &Point<T>) -> reqwest::Result<String>;
+    fn reverse(&self, point: &Point<T>) -> Result<String, Error>;
 }
 
 /// Forward-geocode a coordinate.
@@ -94,5 +89,5 @@ where
     // NOTE TO IMPLEMENTERS: while returned provider point data may not be in
     // lon, lat (x, y) order, Geocoding requires this order in its output Point
     // data. Please pay attention when using returned data to construct Points
-    fn forward(&self, address: &str) -> reqwest::Result<Vec<Point<T>>>;
+    fn forward(&self, address: &str) -> Result<Vec<Point<T>>, Error>;
 }

--- a/src/opencage.rs
+++ b/src/opencage.rs
@@ -58,7 +58,7 @@ mod string_or_int {
 
 // OpenCage has a custom rate-limit header, indicating remaining calls
 // header! { (XRatelimitRemaining, "X-RateLimit-Remaining") => [i32] }
-static XRL: &'static str = "x-ratelimit-remaining";
+static XRL: &str = "x-ratelimit-remaining";
 /// Use this constant if you don't need to restrict a `forward_full` call with a bounding box
 pub static NOBOX: Option<InputBounds<f64>> = None::<InputBounds<f64>>;
 
@@ -198,14 +198,14 @@ impl Opencage {
     /// ```
     ///
     /// ```
-    /// // There are several ways to construct a Point – the Turbofish is necessary
+    /// // There are several ways to construct a Point, such as from a tuple
     /// use geocoding::{Opencage, Point};
     /// use geocoding::opencage::InputBounds;
     /// let oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
     /// let address = "UCL CASA";
-    /// let bbox = InputBounds::new::<Point<f64>>(
-    ///     (-0.13806939125061035, 51.51989264641164).into(),
-    ///     (-0.13427138328552246, 51.52319711775629).into(),
+    /// let bbox = InputBounds::new(
+    ///     (-0.13806939125061035, 51.51989264641164),
+    ///     (-0.13427138328552246, 51.52319711775629),
     /// );
     /// let res = oc.forward_full(&address, bbox).unwrap();
     /// let first_result = &res.results[0];
@@ -715,9 +715,9 @@ mod test {
     fn forward_full_test_pointinto() {
         let oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
         let address = "UCL CASA";
-        let bbox = InputBounds::new::<Point<f64>>(
-            (-0.13806939125061035, 51.51989264641164).into(),
-            (-0.13427138328552246, 51.52319711775629).into(),
+        let bbox = InputBounds::new(
+            (-0.13806939125061035, 51.51989264641164),
+            (-0.13427138328552246, 51.52319711775629),
         );
         let res = oc.forward_full(&address, bbox).unwrap();
         let first_result = &res.results[0];

--- a/src/opencage.rs
+++ b/src/opencage.rs
@@ -214,11 +214,7 @@ impl Opencage {
     ///     "UCL, 188 Tottenham Court Road, London WC1E 6BT, United Kingdom"
     /// );
     /// ```
-    pub fn forward_full<T, U>(
-        &self,
-        place: &str,
-        bounds: U,
-    ) -> Result<OpencageResponse<T>, Error>
+    pub fn forward_full<T, U>(&self, place: &str, bounds: U) -> Result<OpencageResponse<T>, Error>
     where
         T: Float,
         U: Into<Option<InputBounds<T>>>,
@@ -236,7 +232,7 @@ impl Opencage {
         ];
         // If search bounds are passed, use them
         if let Some(bds) = bounds.into() {
-            bd = String::from(InputBounds::from(bds));
+            bd = String::from(bds);
             query.push(("bounds", &bd));
         }
         let mut resp = self
@@ -602,18 +598,18 @@ where
 
 impl<T> InputBounds<T>
 where
-    T: Float
+    T: Float,
 {
     /// Create a new `InputBounds` struct by passing 2 `Point`s defining:
     /// - minimum (bottom-left) longitude and latitude coordinates
     /// - maximum (top-right) longitude and latitude coordinates
     pub fn new<U>(minimum_lonlat: U, maximum_lonlat: U) -> InputBounds<T>
     where
-        U: Into<Point<T>>
+        U: Into<Point<T>>,
     {
         InputBounds {
             minimum_lonlat: minimum_lonlat.into(),
-            maximum_lonlat: maximum_lonlat.into()
+            maximum_lonlat: maximum_lonlat.into(),
         }
     }
 }

--- a/src/opencage.rs
+++ b/src/opencage.rs
@@ -98,6 +98,8 @@ impl Opencage {
     ///
     /// This method passes the `no_record` parameter to the API.
     ///
+    /// # Examples
+    ///
     ///```
     /// use geocoding::{Opencage, Point};
     ///
@@ -161,6 +163,8 @@ impl Opencage {
     ///
     /// This method passes the `no_record` parameter to the API.
     ///
+    /// # Examples
+    ///
     ///```
     /// use geocoding::{Opencage, Point};
     /// use geocoding::opencage::InputBounds;
@@ -173,12 +177,43 @@ impl Opencage {
     ///     Point::new(-0.13806939125061035, 51.51989264641164),
     ///     Point::new(-0.13427138328552246, 51.52319711775629),
     /// );
-    /// // Pass NOBOX if you don't need bounds.
     /// let res = oc.forward_full(&address, bbox).unwrap();
     /// let first_result = &res.results[0];
     /// // the first result is correct
     /// assert_eq!(first_result.formatted, "UCL, 188 Tottenham Court Road, London WC1E 6BT, United Kingdom");
     ///```
+    ///
+    /// ```
+    /// // You can pass NOBOX if you don't need bounds.
+    /// use geocoding::{Opencage, Point};
+    /// use geocoding::opencage::{InputBounds, NOBOX};
+    /// let oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
+    /// let address = "UCL CASA";
+    /// let res = oc.forward_full(&address, NOBOX).unwrap();
+    /// let first_result = &res.results[0];
+    /// assert_eq!(
+    ///     first_result.formatted,
+    ///     "UCL, 188 Tottenham Court Road, London WC1E 6BT, United Kingdom"
+    /// );
+    /// ```
+    ///
+    /// ```
+    /// // There are several ways to construct a Point – the Turbofish is necessary
+    /// use geocoding::{Opencage, Point};
+    /// use geocoding::opencage::InputBounds;
+    /// let oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
+    /// let address = "UCL CASA";
+    /// let bbox = InputBounds::new::<Point<f64>>(
+    ///     (-0.13806939125061035, 51.51989264641164).into(),
+    ///     (-0.13427138328552246, 51.52319711775629).into(),
+    /// );
+    /// let res = oc.forward_full(&address, bbox).unwrap();
+    /// let first_result = &res.results[0];
+    /// assert_eq!(
+    ///     first_result.formatted,
+    ///     "UCL, 188 Tottenham Court Road, London WC1E 6BT, United Kingdom"
+    /// );
+    /// ```
     pub fn forward_full<T, U>(
         &self,
         place: &str,
@@ -657,6 +692,36 @@ mod test {
         let bbox = InputBounds::new(
             Point::new(-0.13806939125061035, 51.51989264641164),
             Point::new(-0.13427138328552246, 51.52319711775629),
+        );
+        let res = oc.forward_full(&address, bbox).unwrap();
+        let first_result = &res.results[0];
+        assert_eq!(
+            first_result.formatted,
+            "UCL, 188 Tottenham Court Road, London WC1E 6BT, United Kingdom"
+        );
+    }
+    #[test]
+    fn forward_full_test_pointfrom() {
+        let oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
+        let address = "UCL CASA";
+        let bbox = InputBounds::new(
+            Point::from((-0.13806939125061035, 51.51989264641164)),
+            Point::from((-0.13427138328552246, 51.52319711775629)),
+        );
+        let res = oc.forward_full(&address, bbox).unwrap();
+        let first_result = &res.results[0];
+        assert_eq!(
+            first_result.formatted,
+            "UCL, 188 Tottenham Court Road, London WC1E 6BT, United Kingdom"
+        );
+    }
+    #[test]
+    fn forward_full_test_pointinto() {
+        let oc = Opencage::new("dcdbf0d783374909b3debee728c7cc10".to_string());
+        let address = "UCL CASA";
+        let bbox = InputBounds::new::<Point<f64>>(
+            (-0.13806939125061035, 51.51989264641164).into(),
+            (-0.13427138328552246, 51.52319711775629).into(),
         );
         let res = oc.forward_full(&address, bbox).unwrap();
         let first_result = &res.results[0];


### PR DESCRIPTION
A (festive) grab bag of updates 🎄:

- Switch to the 2018 Edition
- use latest versions of `Reqwest` and `Geo-Types`
- switch to `Failure` for errors
    - top-level errors are currently basic, but can be down-cast for more detail
- No longer borrow input bounds and points used for forward- and reverse-geocoding, since these are `Copy` types
- Provision of a `new` constructor for `InputBounds`
- No need to explicitly specify that `InputBounds` is an `Option`, by providing an `Into<Option<_>>` impl on `forward_full`
- Provision of a static `NOBOX` item, so search bounds can more easily be omitted without resorting to a turbofish on `None`.
- More robust definition of the OpenCage return value JSON schema
- Returned timestamp data are now converted to `chrono` timestamp objects
- More documentation
- More tests