### PR TITLE
Fix OpenSSL dependency issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/georust/geocoding"
 keywords = ["gecoding", "geo", "gis", "geospatial"]
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
 geo-types = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,8 @@ keywords = ["gecoding", "geo", "gis", "geospatial"]
 readme = "README.md"
 
 [dependencies]
-geo-types = "0.2.0"
+geo-types = "0.3"
 num-traits = "0.2"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest ="0.8.5"
-hyper = "0.11.25"
+reqwest = { version = "0.9" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,17 +13,10 @@
 //! and returns data in that order.
 //!
 static UA_STRING: &'static str = "Rust-Geocoding";
-extern crate geo_types;
+
 pub use geo_types::Point;
 
-extern crate num_traits;
 use num_traits::Float;
-
-extern crate serde;
-use serde::Deserialize;
-
-extern crate reqwest;
-use reqwest::{header, Client};
 
 // The OpenCage geocoding provider
 pub mod opencage;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,17 +19,11 @@ pub use geo_types::Point;
 extern crate num_traits;
 use num_traits::Float;
 
-#[macro_use]
-extern crate serde_derive;
-
 extern crate serde;
 use serde::Deserialize;
 
 extern crate reqwest;
 use reqwest::{header, Client};
-
-#[macro_use]
-extern crate hyper;
 
 // The OpenCage geocoding provider
 pub mod opencage;

--- a/src/opencage.rs
+++ b/src/opencage.rs
@@ -144,7 +144,7 @@ impl Opencage {
     /// let res = oc.forward_full(&address, &Some(bbox.into())).unwrap();
     /// let first_result = &res.results[0];
     /// // the first result is correct
-    /// assert_eq!(first_result.formatted, "UCL, 188 Tottenham Court Road, London WC1E 6BT, United Kingdom");
+    /// assert_eq!(first_result.formatted, "UCL, 188 Tottenham Court Road, London W1T 7PE, United Kingdom");
     ///```
     pub fn forward_full<T>(
         &self,
@@ -596,7 +596,7 @@ mod test {
         let first_result = &res.results[0];
         assert_eq!(
             first_result.formatted,
-            "UCL, 188 Tottenham Court Road, London WC1E 6BT, United Kingdom"
+            "UCL, 188 Tottenham Court Road, London W1T 7PE, United Kingdom"
         );
     }
 }

--- a/src/opencage.rs
+++ b/src/opencage.rs
@@ -23,19 +23,17 @@
 //! // "Carrer de Calatrava, 68, 08017 Barcelona, Spain"
 //! println!("{:?}", res.unwrap());
 //! ```
-use std::str::FromStr;
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::HashMap,
+    str::FromStr,
+    sync::{Arc, Mutex},
+};
 
-use super::num_traits::Float;
-use std::collections::HashMap;
+use num_traits::Float;
+use reqwest::{header, Client};
+use serde::Deserialize;
 
-use super::reqwest;
-use super::Deserialize;
-use super::UA_STRING;
-use super::{header, Client};
-
-use super::Point;
-use super::{Forward, Reverse};
+use super::{Forward, Point, Reverse, UA_STRING};
 
 /// An instance of the Opencage Geocoding service
 pub struct Opencage {


### PR DESCRIPTION
The dependency on _reqwest 0.8_ caused issues with system dependencies on a specific OpenSSL version. These issues disappeared after upgrading to _reqwest 0.9_, which relies on _native-tls_ by default.

Other notable changes:
* Upgraded _edition_ to "2018"
* Adjusted an expected test result that changed slightly
* Reduced redundant code
* Removed unused dependencies