### PR TITLE
Bounds in Opencage response need to be optional

### DIFF
--- a/src/opencage.rs
+++ b/src/opencage.rs
@@ -495,7 +495,7 @@ where
     T: Float,
 {
     pub annotations: Option<Annotations<T>>,
-    pub bounds: Bounds<T>,
+    pub bounds: Option<Bounds<T>>,
     pub components: HashMap<String, String>,
     pub confidence: i8,
     pub formatted: String,


### PR DESCRIPTION
Failure to parse an Opencage response of a forward_full() query:
```
missing field `bounds` at line 1 column 9934
```