### PR TITLE
Make OpenCage schema a little more robust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geocoding"
 description = "Geocoding library for Rust"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Stephan Hügel <urschrei@gmail.com>", "Blake Grotewold <hello@grotewold.me>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/georust/geocoding"

--- a/src/opencage.rs
+++ b/src/opencage.rs
@@ -529,6 +529,7 @@ pub struct Currency {
     pub decimal_mark: String,
     pub html_entity: String,
     pub iso_code: String,
+    #[serde(with = "string_or_int")]
     pub iso_numeric: String,
     pub name: String,
     pub smallest_denomination: i16,
@@ -552,6 +553,7 @@ pub struct Timezone {
     pub name: String,
     pub now_in_dst: i16,
     pub offset_sec: i32,
+    #[serde(with = "string_or_int")]
     pub offset_string: String,
     #[serde(with = "string_or_int")]
     pub short_name: String,


### PR DESCRIPTION
OpenCage seems to switch between String and i32 on certain fields. This change allows us to cope with that.