### PR TITLE
Return option from reverse geocoding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub use crate::openstreetmap::Openstreetmap;
 /// let res = oc.reverse(&p).unwrap();
 /// assert_eq!(
 ///     res,
-///     "Carrer de Calatrava, 68, 08017 Barcelona, Spain"
+///     Some("Carrer de Calatrava, 68, 08017 Barcelona, Spain".to_string())
 /// );
 /// ```
 pub trait Reverse<T>
@@ -58,7 +58,7 @@ where
     // NOTE TO IMPLEMENTERS: Point coordinates are lon, lat (x, y)
     // You may have to provide these coordinates in reverse order,
     // depending on the provider's requirements (see e.g. OpenCage)
-    fn reverse(&self, point: &Point<T>) -> Result<String, Error>;
+    fn reverse(&self, point: &Point<T>) -> Result<Option<String>, Error>;
 }
 
 /// Forward-geocode a coordinate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@
 //! Over time, a variety of providers will be added. Each provider may implement one or both
 //! of the `Forward` and `Reverse` traits, which provide forward– and reverse-geocoding methods.
 //!
-//! Note that for the `reverse` method, the return type is simply `String`,
-//! As this is the lowest common denominator reverse-geocoding result.
+//! Note that for the `reverse` method, the return type is simply `Option<String>`,
+//! as this is the lowest common denominator reverse-geocoding result.
 //! Individual providers may implement additional methods, which return more
 //! finely-structured and/or extensive data, and enable more specific query tuning.
 //! Coordinate data are specified using the [`Point`](struct.Point.html) struct, which has several
@@ -36,7 +36,7 @@ pub use crate::openstreetmap::Openstreetmap;
 /// Reverse-geocode a coordinate.
 ///
 /// This trait represents the most simple and minimal implementation
-/// available from a given geocoding provider: an address formatted as a String.
+/// available from a given geocoding provider: some address formatted as Option<String>.
 ///
 /// Examples
 ///

--- a/src/opencage.rs
+++ b/src/opencage.rs
@@ -263,7 +263,7 @@ where
     /// returned `String` can be found [here](https://blog.opencagedata.com/post/99059889253/good-looking-addresses-solving-the-berlin-berlin)
     ///
     /// This method passes the `no_annotations` and `no_record` parameters to the API.
-    fn reverse(&self, point: &Point<T>) -> Result<String, Error> {
+    fn reverse(&self, point: &Point<T>) -> Result<Option<String>, Error> {
         let mut resp = self
             .client
             .get(&self.endpoint)
@@ -295,7 +295,7 @@ where
                 **mutex = Some(h)
             }
         }
-        Ok(address.formatted.to_string())
+        Ok(Some(address.formatted.to_string()))
     }
 }
 
@@ -596,7 +596,7 @@ mod test {
         let res = oc.reverse(&p);
         assert_eq!(
             res.unwrap(),
-            "Carrer de Calatrava, 68, 08017 Barcelona, Spain"
+            Some("Carrer de Calatrava, 68, 08017 Barcelona, Spain".to_string())
         );
     }
     #[test]

--- a/src/openstreetmap.rs
+++ b/src/openstreetmap.rs
@@ -219,7 +219,7 @@ where
     /// returned `String` can be found [here](https://nominatim.org/release-docs/develop/api/Reverse/)
     ///
     /// This method passes the `format` parameter to the API.
-    fn reverse(&self, point: &Point<T>) -> Result<String, Error> {
+    fn reverse(&self, point: &Point<T>) -> Result<Option<String>, Error> {
         let mut resp = self
             .client
             .get(&format!("{}reverse", self.endpoint))
@@ -232,7 +232,7 @@ where
             .error_for_status()?;
         let res: OpenstreetmapResponse<T> = resp.json()?;
         let address = &res.features[0];
-        Ok(address.properties.display_name.to_string())
+        Ok(Some(address.properties.display_name.to_string()))
     }
 }
 
@@ -397,7 +397,7 @@ mod test {
         let res = osm.reverse(&p);
         assert_eq!(
             res.unwrap(),
-            "68, Carrer de Calatrava, les Tres Torres, Sarrià - Sant Gervasi, Barcelona, Barcelonès, Barcelona, Catalunya, 08017, España",
+            Some("68, Carrer de Calatrava, les Tres Torres, Sarrià - Sant Gervasi, Barcelona, Barcelonès, Barcelona, Catalunya, 08017, España".to_string()),
         );
     }
 }


### PR DESCRIPTION
In some cases/some providers, there exists no response from reverse gecoding. I ran into this issue while adding a new geocoding provider #26 
The proposed solution to address this, is to return an Option<String>. Alternatives would be an empty string or an empty Vec<String> similar to forward geocoding.