### PR TITLE
Permit serialization of responses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,15 @@
 # Changes
 
+## 0.1.4
+
+- Made Opencage and Openstreetmap responses/results serializable so it's easier to store them afterwards
+  - <https://github.com/georust/geocoding/pull/31>
+
 ## 0.1.0
 
-* Added OpenStreetMap provider
-    * <https://github.com/georust/geocoding/pull/22>
-* Fixes to keep up with OpenCage schema updates
-    * <https://github.com/georust/geocoding/pull/23>
-* Switch to 2018 edition, use of `Failure`, more robust OpenCage schema definition, more ergonomic specification of bounds for OpenCage
-    * https://github.com/georust/geocoding/pull/15
+- Added OpenStreetMap provider
+  - <https://github.com/georust/geocoding/pull/22>
+- Fixes to keep up with OpenCage schema updates
+  - <https://github.com/georust/geocoding/pull/23>
+- Switch to 2018 edition, use of `Failure`, more robust OpenCage schema definition, more ergonomic specification of bounds for OpenCage
+  - https://github.com/georust/geocoding/pull/15

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ use num_traits::Float;
 use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
 use reqwest::Client;
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Serialize};
 
 // The OpenCage geocoding provider
 pub mod opencage;

--- a/src/openstreetmap.rs
+++ b/src/openstreetmap.rs
@@ -16,11 +16,11 @@
 //! let res = osm.forward(&address);
 //! assert_eq!(res.unwrap(), vec![Point::new(11.5761796, 48.1599218)]);
 //! ```
-use crate::Deserialize;
 use crate::InputBounds;
 use crate::Point;
 use crate::UA_STRING;
 use crate::{Client, HeaderMap, HeaderValue, USER_AGENT};
+use crate::{Deserialize, Serialize};
 use crate::{Forward, Reverse};
 use failure::Error;
 use num_traits::Float;
@@ -286,7 +286,7 @@ where
 ///  ]
 ///}
 ///```
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct OpenstreetmapResponse<T>
 where
     T: Float,
@@ -297,7 +297,7 @@ where
 }
 
 /// A geocoding result
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct OpenstreetmapResult<T>
 where
     T: Float,
@@ -309,7 +309,7 @@ where
 }
 
 /// Geocoding result properties
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ResultProperties {
     pub place_id: u64,
     pub osm_type: String,
@@ -323,7 +323,7 @@ pub struct ResultProperties {
 }
 
 /// Address details in the result object
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AddressDetails {
     pub city: Option<String>,
     pub city_district: Option<String>,
@@ -340,7 +340,7 @@ pub struct AddressDetails {
 }
 
 /// A geocoding result geometry
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ResultGeometry<T>
 where
     T: Float,


### PR DESCRIPTION
It makes it easier to store.

Here is a code example with [diesel](https://github.com/diesel-rs/diesel):

```rust
use chrono::NaiveDateTime;
use diesel_as_jsonb::AsJsonb;
use geocoding::opencage::Results as OpenCageResult;
use geocoding::openstreetmap::OpenstreetmapResult as OSMResult;
use uuid::Uuid;

use crate::schema::locations;

#[derive(Serialize, Deserialize, Debug, AsJsonb)]
pub enum LocationData {
    OSM(OSMResult<f64>),
    OpenCage(OpenCageResult<f64>),
}

#[derive(Queryable)]
pub struct Location {
    pub id: Uuid,
    pub provider: String,
    pub data: LocationData,
    pub label: String,
    pub lat: f64,
    pub lon: f64,
    pub created_at: NaiveDateTime,
    pub updated_at: NaiveDateTime,
}

#[derive(Insertable)]
#[table_name = "locations"]
pub struct NewLocation {
    pub provider: String,
    pub data: LocationData,
    pub label: String,
    pub lat: f64,
    pub lon: f64,
}
```