### PR TITLE
Provide rustls feature

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
   - <https://github.com/georust/geocoding/pull/38>
 - Derive `Clone` for Opencage results
   - <https://github.com/georust/geocoding/pull/38/commits/61019fe0da2bb06580fcf7188eb2381a67d564d2>
+- Allow usage of `rustls-tls` feature
 
 ## 0.2.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ geo-types = "0.6"
 num-traits = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.10.6", features = ["blocking", "json"] }
+reqwest = { version = "0.10", default-features = false, features = ["blocking", "json"] }
 hyper = "0.13.6"
 chrono = { version = "0.4", features = ["serde"] }
+
+[features]
+default = ["reqwest/default"]
+rustls-tls = ["reqwest/rustls-tls"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,16 @@
 //! `Geocoding` **always** requires [`Point`](struct.Point.html) data in `[Longitude, Latitude]` (`x, y`) order,
 //! and returns data in that order.
 //!
+//! ### Usage of rustls
+//!
+//! If you like to use [rustls](https://github.com/ctz/rustls) instead of OpenSSL
+//! you can enable the `rustls-tls` feature in your `Cargo.toml`:
+//!
+//!```toml
+//![dependencies]
+//!geocoding = { version = "*", default-features = false, features = ["rustls-tls"] }
+//!```
+
 static UA_STRING: &str = "Rust-Geocoding";
 
 use chrono;


### PR DESCRIPTION
In some environments openssl is not available so with `rustls-tls` we can solve that problem.