### PR TITLE
Add village to result object

### DIFF
--- a/src/openstreetmap.rs
+++ b/src/openstreetmap.rs
@@ -331,6 +331,7 @@ pub struct AddressDetails {
     pub public_building: Option<String>,
     pub state: Option<String>,
     pub suburb: Option<String>,
+    pub village: Option<String>,
 }
 
 /// A geocoding result geometry


### PR DESCRIPTION
Sometimes `village` is set and `city` is empty.

Example:

[49.321286111111114,8.681305555555555](https://nominatim.openstreetmap.org/search?q=49.321286111111114,8.681305555555555&format=json&addressdetails=1)
