### PR TITLE
Currency field in annotations might not be present

### DIFF
--- a/src/opencage.rs
+++ b/src/opencage.rs
@@ -550,7 +550,7 @@ where
     pub mercator: Option<HashMap<String, T>>,
     pub osm: Option<HashMap<String, String>>,
     pub callingcode: i16,
-    pub currency: Currency,
+    pub currency: Option<Currency>,
     pub flag: String,
     pub geohash: String,
     pub qibla: T,


### PR DESCRIPTION
Like in this case for example:
 https://api.opencagedata.com/geocode/v1/json?q=10.4645969,-64.1781702&no_annotations=0&no_record=1&key=<OPENCAGE_KEY_HERE>
