### PR TITLE
Remove chrono dependency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,30 @@
 # Changes
 
+## unreleased
+
+- Remove `chrono` dependency
+
+### Breaking Changes
+
+Due to previous security issues caused by the `chrono` crate
+the `NaiveDateTime` was replaces by a `UnixTime` type:
+
+```diff
+- use chrono::NaiveDateTime;
+- use geocoding::opencage::Timestamp;
++ use geocoding::opencage::{Timestamp, UnixTime};
+
+  let created_http = "Mon, 16 May 2022 14:52:47 GMT".to_string();
+
+  let ts_in_seconds = 1_652_712_767_i64;
+- let created_unix = NaiveDateTime::from_timestamp(ts_in_seconds, 0);
++ let created_unix = UnixTime::from_seconds(ts_in_seconds);
+
+  let timestamp = Timestamp { created_http, created_unix };
+
++ assert_eq!(ts_in_seconds, created_unix.as_seconds());
+```
+
 ## 0.4.0
 - Update CI to use same Rust versions as geo
 - Switch GeoAdmin API to WGS84

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.11", default-features = false, features = ["default-tls", "blocking", "json"] }
 hyper = "0.14.11"
-chrono = { version = "0.4", features = ["serde"] }
 
 [features]
 default = ["reqwest/default"]

--- a/src/geoadmin.rs
+++ b/src/geoadmin.rs
@@ -368,7 +368,6 @@ pub struct GeoAdminForwardLocation<T>
 where
     T: Float + Debug,
 {
-    id: Option<usize>,
     pub properties: ForwardLocationProperties<T>,
 }
 
@@ -417,7 +416,6 @@ pub struct GeoAdminReverseResponse {
 /// A reverse geocoding result
 #[derive(Debug, Deserialize)]
 pub struct GeoAdminReverseLocation {
-    id: String,
     #[serde(rename = "featureId")]
     pub feature_id: String,
     #[serde(rename = "layerBodId")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 
 static UA_STRING: &str = "Rust-Geocoding";
 
-pub use geo_types::{Coordinate, Point};
+pub use geo_types::{Coord, Point};
 use num_traits::Float;
 use reqwest::blocking::Client;
 use reqwest::header::ToStrError;
@@ -108,7 +108,7 @@ where
 /// let res: Vec<Point<f64>> = oc.forward(address).unwrap();
 /// assert_eq!(
 ///     res,
-///     vec![Point(Coordinate { x: 11.5884858, y: 48.1700887 })]
+///     vec![Point(Coord { x: 11.5884858, y: 48.1700887 })]
 /// );
 /// ```
 pub trait Forward<T>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,6 @@
 
 static UA_STRING: &str = "Rust-Geocoding";
 
-use chrono;
 pub use geo_types::{Coordinate, Point};
 use num_traits::Float;
 use reqwest::blocking::Client;

--- a/src/opencage.rs
+++ b/src/opencage.rs
@@ -24,8 +24,6 @@
 //! // "Carrer de Calatrava, 68, 08017 Barcelone, Espagne"
 //! println!("{:?}", res.unwrap());
 //! ```
-use crate::chrono::naive::serde::ts_seconds::deserialize as from_ts;
-use crate::chrono::NaiveDateTime;
 use crate::DeserializeOwned;
 use crate::GeocodingError;
 use crate::InputBounds;
@@ -608,8 +606,20 @@ pub struct Status {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Timestamp {
     pub created_http: String,
-    #[serde(deserialize_with = "from_ts")]
-    pub created_unix: NaiveDateTime,
+    pub created_unix: UnixTime,
+}
+
+/// Primitive unix timestamp
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct UnixTime(i64);
+
+impl UnixTime {
+    pub const fn as_seconds(self) -> i64 {
+        self.0
+    }
+    pub const fn from_seconds(seconds: i64) -> Self {
+        Self(seconds)
+    }
 }
 
 /// Bounding-box metadata

--- a/src/opencage.rs
+++ b/src/opencage.rs
@@ -635,7 +635,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::Coordinate;
+    use crate::Coord;
 
     #[test]
     fn reverse_test() {
@@ -666,7 +666,7 @@ mod test {
         let res = oc.forward(&address);
         assert_eq!(
             res.unwrap(),
-            vec![Point(Coordinate {
+            vec![Point(Coord {
                 x: 11.5884858,
                 y: 48.1700887
             })]


### PR DESCRIPTION
... and instead of binding the user to a specific time library, the `UnixTime` should be converted by the user depending on the use case.